### PR TITLE
Reformat completion results to match common language server conventions

### DIFF
--- a/fortls/intrinsics.py
+++ b/fortls/intrinsics.py
@@ -35,6 +35,8 @@ class fortran_intrinsic_obj:
             return 'INTRINSIC'
 
     def get_snippet(self, name_replace=None, drop_arg=-1):
+        if self.type == 14:
+            return None, None
         arg_snip = None
         if self.args == "":
             if self.type == 14:

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -617,19 +617,25 @@ class LangServer:
 
         def build_comp(candidate, name_only=False, name_replace=None, is_interface=False):
             comp_obj = {}
+            call_sig = None
             if name_only:
                 comp_obj["label"] = candidate.name
             else:
-                comp_obj["label"], snippet = candidate.get_snippet(name_replace)
+                comp_obj["label"] = candidate.name
+                if name_replace is not None:
+                    comp_obj["label"] = name_replace
+                call_sig, snippet = candidate.get_snippet(name_replace)
                 if snippet is not None:
                     if self.use_signature_help and (not is_interface):
                         arg_open = snippet.find('(')
                         if arg_open > 0:
-                            snippet = snippet[:arg_open] + "(${0})"
+                            snippet = snippet[:arg_open]
                     comp_obj["insertText"] = snippet
                     comp_obj["insertTextFormat"] = 2
             comp_obj["kind"] = map_types(candidate.get_type())
             comp_obj["detail"] = candidate.get_desc()
+            if call_sig is not None:
+                comp_obj["detail"] += ' ' + call_sig
             doc_str, _ = candidate.get_documentation()
             if doc_str is not None:
                 comp_obj["documentation"] = doc_str

--- a/fortls/objects.py
+++ b/fortls/objects.py
@@ -255,9 +255,7 @@ class fortran_scope:
         return 'unknown'
 
     def get_snippet(self, name_replace=None, drop_arg=-1):
-        if name_replace is not None:
-            return name_replace, None
-        return self.name, None
+        return None, None
 
     def get_documentation(self, long=False):
         return None, False
@@ -574,9 +572,9 @@ class fortran_function(fortran_subroutine):
     def get_desc(self):
         # desc = None
         if self.result_obj is not None:
-            return self.result_obj.get_desc()
+            return self.result_obj.get_desc() + ' FUNCTION'
         if self.return_type is not None:
-            return self.return_type
+            return self.return_type + ' FUNCTION'
         return 'FUNCTION'
 
     def is_callable(self):
@@ -773,7 +771,7 @@ class fortran_obj:
         if self.link_obj is not None:
             return self.link_obj.get_snippet(name, drop_arg)
         # Normal variable
-        return name, None
+        return None, None
 
     def get_documentation(self, long=False):
         doc_str = self.desc
@@ -831,7 +829,7 @@ class fortran_meth(fortran_obj):
             name = name_replace
         if self.link_obj is not None:
             return self.link_obj.get_snippet(name, self.drop_arg)
-        return name, None
+        return None, None
 
     def get_type(self):
         if self.link_obj is not None:

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -152,6 +152,7 @@ def test_comp():
         assert len(result_array["items"]) == checks[0]
         if checks[0] > 0:
             assert result_array["items"][0]["label"] == checks[1]
+            assert result_array["items"][0]["detail"] == checks[2]
 
     def comp_request(file_path, line, char):
         return write_rpc_request(1, "textDocument/completion", {
@@ -190,25 +191,25 @@ def test_comp():
     assert errcode == 0
     #
     exp_results = (
-        [1, "myfun(n, xval)"],
-        [4, "glob_sub(n, xval, yval)"],
-        [1, "bound_nopass(a, b)"],
-        [1, "bound_pass(arg1)"],
-        [1, "stretch_vector"],
-        [6, "scale"],
-        [2, "n"],
-        [1, "val"],
-        [1, "point"],
-        [1, "distance"],
-        [2, "x"],
-        [2, "val1"],
-        [2, "val1"],
-        [1, "abs_interface"],
-        [1, "DIMENSION(:)"],
-        [3, "INTENT(IN)"],
-        [3, "res0"],
-        [4, "res0"],
-        [5, "res0"]
+        [1, "myfun", "DOUBLE PRECISION FUNCTION myfun(n, xval)"],
+        [4, "glob_sub", "SUBROUTINE glob_sub(n, xval, yval)"],
+        [1, "bound_nopass", "SUBROUTINE bound_nopass(a, b)"],
+        [1, "bound_pass", "SUBROUTINE bound_pass(arg1)"],
+        [1, "stretch_vector", "TYPE(scaled_vector)"],
+        [6, "scale", "TYPE(scale_type)"],
+        [2, "n", "INTEGER(4)"],
+        [1, "val", "REAL(8)"],
+        [1, "point", "TYPE"],
+        [1, "distance", "REAL"],
+        [2, "x", "REAL"],
+        [2, "val1", "REAL(8)"],
+        [2, "val1", "REAL(8)"],
+        [1, "abs_interface", "SUBROUTINE"],
+        [1, "DIMENSION(:)", "KEYWORD"],
+        [3, "INTENT(IN)", "KEYWORD"],
+        [3, "res0", "INTEGER"],
+        [4, "res0", "INTEGER"],
+        [5, "res0", "INTEGER"]
     )
     assert len(exp_results)+1 == len(results)
     for i in range(len(exp_results)):


### PR DESCRIPTION
- Use name only in label field
- Provide signature and type in detail field
- Remove parentheses from function/subroutine completion results when signature help is available