### PR TITLE
Try Windows-1252 encoding on failure to decode utf-8 at file load

### DIFF
--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -56,9 +56,14 @@ def read_file_split(filepath):
     # Read and add file from disk
     try:
         if PY3K:
-            with open(filepath, 'r', encoding="utf-8") as fhandle:
-                contents = re.sub(r'\t', r'  ', fhandle.read())
-                contents_split = contents.splitlines()
+            try:
+                with open(filepath, 'r', encoding="utf-8") as fhandle:
+                    contents = re.sub(r'\t', r'  ', fhandle.read())
+                    contents_split = contents.splitlines()
+            except UnicodeDecodeError:
+                with open(filepath, 'r', encoding="Windows-1252") as fhandle:
+                    contents = re.sub(r'\t', r'  ', fhandle.read())
+                    contents_split = contents.splitlines()
         else:
             with open(filepath, 'r') as fhandle:
                 contents = re.sub(r'\t', r'  ', fhandle.read())


### PR DESCRIPTION
For a lot of Fortran code created with Visual Studio under Windows, the encoding is Windows-1252. In case of error when loading a file as utf-8 encoded, try the Windows encoding. If this fails, just fail and do not try to further detect.

One could try to further detect using the `chardet` library or something similar, but this is very slow and not reliable. The problem is that the files are nearly always mostly ASCII and then in the middle of a comment at the end, you have an accented character like è in a comment. The `chardet` library is only doing detection on the first characters of the file because it is a very slow process. This is why I am doing just a single "Try Windows and fail if both are not working."
