### PR TITLE
add info about python 3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Fortran Language Server (beta)
 .. image:: https://img.shields.io/github/license/hansec/fortran-language-server.svg
      :target: https://github.com/hansec/fortran-language-server/blob/master/LICENSE
 
-A Fortran implementation of the `Language Server Protocol <https://github.com/Microsoft/language-server-protocol>`_ using Python (2.7+).
+A Fortran implementation of the `Language Server Protocol <https://github.com/Microsoft/language-server-protocol>`_ using Python (2.7+ or 3.0+).
 
 Editor extensions using this language server to provide autocomplete and other IDE-like functionality are available for `Atom <https://atom.io/packages/ide-fortran>`_, `Visual Studio Code <https://marketplace.visualstudio.com/items?itemName=hansec.fortran-ls>`_, `(Neo)vim <https://github.com/hansec/fortran-language-server/wiki/Using-forts-with-vim>`_, and `Emacs <https://github.com/MagB93/lsp-fortran>`_.
 


### PR DESCRIPTION
I think it's better to state explicitly python 3 compatibility, as this is not automatic.
I'm used to working with code supporting either python 2 or 3, so without looking into the code, I didn't even know python 3 was also supported.