### PR TITLE
Updated logic for trailing ampersand to check if it is a comment line

### DIFF
--- a/fortls/parse_fortran.py
+++ b/fortls/parse_fortran.py
@@ -67,7 +67,7 @@ SQ_STRING_REGEX = re.compile(r'\'[^\']*\'', re.I)
 DQ_STRING_REGEX = re.compile(r'\"[^\"]*\"', re.I)
 LINE_LABEL_REGEX = re.compile(r'[ ]*([0-9]+)[ ]+', re.I)
 #
-FIXED_COMMENT_LINE_MATCH = re.compile(r'(!|c|d|\*)', re.I)
+FIXED_COMMENT_LINE_MATCH = re.compile(r'^(!|c|d|\*)', re.I)
 FIXED_CONT_REGEX = re.compile(r'(     [\S])')
 #
 FREE_COMMENT_LINE_MATCH = re.compile(r'([ ]*!)')
@@ -90,9 +90,10 @@ def detect_fixed_format(file_lines):
         if tmp_match and tmp_match.start(1) < 6:
             return False
         # Trailing ampersand indicates free or intersection format
-        line_end = line.split('!')[0].strip()
-        if len(line_end) > 0 and line_end[-1] == '&':
-            return False
+        if not FIXED_COMMENT_LINE_MATCH.match(line):
+            line_end = line.split('!')[0].strip()
+            if len(line_end) > 0 and line_end[-1] == '&':
+                return False
     return True
 
 

--- a/fortls/parse_fortran.py
+++ b/fortls/parse_fortran.py
@@ -67,7 +67,7 @@ SQ_STRING_REGEX = re.compile(r'\'[^\']*\'', re.I)
 DQ_STRING_REGEX = re.compile(r'\"[^\"]*\"', re.I)
 LINE_LABEL_REGEX = re.compile(r'[ ]*([0-9]+)[ ]+', re.I)
 #
-FIXED_COMMENT_LINE_MATCH = re.compile(r'^(!|c|d|\*)', re.I)
+FIXED_COMMENT_LINE_MATCH = re.compile(r'(!|c|d|\*)', re.I)
 FIXED_CONT_REGEX = re.compile(r'(     [\S])')
 #
 FREE_COMMENT_LINE_MATCH = re.compile(r'([ ]*!)')


### PR DESCRIPTION
I had a F77 file where the last character of a comment was an ampersand, and this erroneously made fortls treat it as a free-form file.  This is a minor fix to address this.