### PR TITLE
Script to make local exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .vscode
+fortls*.exe

--- a/make_local_exe.py
+++ b/make_local_exe.py
@@ -1,0 +1,6 @@
+from distlib.scripts import ScriptMaker
+maker = ScriptMaker('.', '.')
+# maker.executable = 'C:\\miniconda\\miniconda3\\python.exe'
+with open('fortls.py') as f:
+    maker.script_template = f.read()
+maker.make('fortls = fortls')


### PR DESCRIPTION
I prefer to keep my Python environment as "clean" as possible, so I wanted to stop "installing" fortls essentially just to get the executable for VS Code to play nice.

I have added a script that uses the `distlib` package (which is what pip uses a fork of to create its executables) to build *.exe files and put them in the folder with the git repository.  

This will actually make it much easier to upgrade when there are new releases because I can just set my git repo to follow the master branch of this repo, and then if I get notified of a new release, I can simply do a git pull to update.  The executable generated by this script will dynamically use whatever version of the package is in the folder next to it, so there is no need to remake the *.exe.  

Because the exe will be present in the repo directory, but for obvious reasons don't want to commit the exe itself, we also add it to the `.gitignore`.

It is also worth noting that essentially what this does is make a copy of the `fortls.py` file and embeds it in the executable, so updates to that file will not be reflected in the executable without a remake. 

That said, it seems obvious from the `..` added to the path in that script that it was intended to be used for some purpose like this one, which makes it curious that some capability like this wouldn't already be provided somewhere.  It doesn't seem that pip is using this script either, so, for my curiosity, if this is not its original purpose, what is its purpose exactly?