### PR TITLE
README: add fix for possible installation error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,17 @@ Installation
 
 ``pip install fortran-language-server``
 
+If you get the following error:
+
+   ``'install_requires' must be a string or list of strings containing valid project/version requirement specifiers``
+
+try updating setuptools:
+
+::
+
+    pip install -U setuptools
+    pip install fortran-language-server
+
 Language server settings
 ------------------------
 


### PR DESCRIPTION
Since commit 2e6f2f4 (Do not install future and argparse unless
necessary, 2019-09-18), the syntax used in the 'install_requires' field
of `setup.py` is not compatible with very old versions of setuptools.

Add a note to the README to direct users to upgrade setuptools if they
get this error when installing fortran-language-server.

---
This tripped me up today on Ubuntu 14.04 so I thought I'd add it to the README. The [python langage server](https://github.com/palantir/python-language-server) README has similar wording.