### PR TITLE
Includes command line option to disable diagnostics

### DIFF
--- a/fortls/__init__.py
+++ b/fortls/__init__.py
@@ -89,6 +89,10 @@ def main():
         help="Maximum comment line length (default: disabled)"
     )
     parser.add_argument(
+        '--disable_diagnostics', action="store_true",
+        help="Disable diagnostics"
+    )
+    parser.add_argument(
         '--debug_log', action="store_true",
         help="Generate debug log in project root folder"
     )
@@ -188,7 +192,8 @@ def main():
         "sort_keywords": (not args.preserve_keyword_order),
         "enable_code_actions": (args.enable_code_actions or args.debug_actions),
         "max_line_length": args.max_line_length,
-        "max_comment_line_length": args.max_comment_line_length
+        "max_comment_line_length": args.max_comment_line_length,
+        "disable_diagnostics": args.disable_diagnostics,
     }
     if args.hover_language is not None:
         settings["hover_language"] = args.hover_language

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -96,6 +96,7 @@ class LangServer:
         self.hover_language = settings.get("hover_language", "fortran90")
         self.sort_keywords = settings.get("sort_keywords", True)
         self.enable_code_actions = settings.get("enable_code_actions", False)
+        self.disable_diagnostics = settings.get("disable_diagnostics", False)
         self.max_line_length = settings.get("max_line_length", -1)
         self.max_comment_line_length = settings.get("max_comment_line_length", -1)
         # Set object settings
@@ -1234,7 +1235,8 @@ class LangServer:
             self.link_version = (self.link_version + 1) % 1000
             for _, file_obj in self.workspace.items():
                 file_obj.ast.resolve_links(self.obj_tree, self.link_version)
-        self.send_diagnostics(uri)
+        if not self.disable_diagnostics:
+            self.send_diagnostics(uri)
 
     def update_workspace_file(self, filepath, read_file=False, allow_empty=False, update_links=False):
         # Update workspace from file contents and path


### PR DESCRIPTION
Thanks a lot @hansec for this great project.

The need for an option to disable diagnostics is already documented in issue #150.
I've noticed a few false-positives in my Fortran code base and whenever possible I'll try to open PRs or at least open issues with minimal examples. Until these are fixed, it would still be nice to have the option to disable diagnostics all together.

If you want any changes, feel free to request them or just push directly to this branch 😄 