### PR TITLE
Update textDocumentSync server capabilities

### DIFF
--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -283,7 +283,11 @@ class LangServer:
             "implementationProvider": True,
             "renameProvider": True,
             "workspaceSymbolProvider": True,
-            "textDocumentSync": self.sync_type
+            "textDocumentSync": {
+                "openClose": True,
+                "change": self.sync_type,
+                "save": True,
+            },
         }
         if self.use_signature_help:
             server_capabilities["signatureHelpProvider"] = {

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -41,11 +41,17 @@ def test_init():
         #     "documentSymbolProvider": true,
         #     "referencesProvider": True,
         #     "hoverProvider": true,
-        #     "textDocumentSync": 2
+        #     "textDocumentSync": {
+        #          "openClose": True,
+        #          "change": 2,
+        #          "save": True,
+        #     },
         # }
         #
         assert "capabilities" in result_dict
-        assert result_dict["capabilities"]["textDocumentSync"] == 2
+        assert result_dict["capabilities"]["textDocumentSync"]["openClose"] == True
+        assert result_dict["capabilities"]["textDocumentSync"]["change"] == 2
+        assert result_dict["capabilities"]["textDocumentSync"]["save"] == True
         assert result_dict["capabilities"]["definitionProvider"] is True
         assert result_dict["capabilities"]["documentSymbolProvider"] is True
         assert result_dict["capabilities"]["hoverProvider"] is True


### PR DESCRIPTION
The README states that "Diagnostics are only updated when files are
saved or opened/closed". However, I noticed that during my usage of
fortls with Neovim through the builtin LSP implementation, saving a file
did not cause the diagnostics to update.

After digging into Neovim's code I noticed that it never sent out any
`textDocument/didSave` notifications to the client. Initially I thought
this was a bug on their end until I noticed that the reason why Neovim
didn't send those notifications was because the server (fortls) did not
provide the corresponding server capability. Instead, it only provided
an integer indicating the `textDocumentSyncKind` for the `change`
notifications.

Looking into the specification of the LSP here [1] I noticed that the
server should/can actually provide a more detailed description of its
capabilities. This commit, does exactly that.

[1]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didClose
Notice the final structure of the `TextDocumentSyncOptions` at the end
of the linked paragraph.