### PR TITLE
Do not require parentheses for the 'defined' preprocessor operator

### DIFF
--- a/fortls/parse_fortran.py
+++ b/fortls/parse_fortran.py
@@ -1066,7 +1066,7 @@ def preprocess_file(contents_split, file_path=None, pp_defs={}, include_dirs=[],
             return expr
 
         def replace_defined(line):
-            DEFINED_REGEX = re.compile(r'defined[ ]*\([ ]*([a-z_][a-z0-9_]*)[ ]*\)', re.I)
+            DEFINED_REGEX = re.compile(r'defined[ ]*\(?[ ]*([a-z_][a-z0-9_]*)[ ]*\)?', re.I)
             i0 = 0
             out_line = ""
             for match in DEFINED_REGEX.finditer(line):


### PR DESCRIPTION
The regex that checks for preprocessor macros using the `defined`
operator assumes that the macro that follows the operator is between
parenthesis. However, the syntax for the `defined` operator does not
require parenthesis, at least in GNU Cpp [1] and Intel fpp [2], arguably
the two most commonly used Fortran preprocessors.

Tweak the regex by allowing the opening and closing parenthesis zero or
once.

[1] https://gcc.gnu.org/onlinedocs/gcc-10.2.0/cpp/Defined.html#Defined
[2] https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/optimization-and-programming-guide/fpp-preprocessing/using-fpp-preprocessor-directives.html
