### PR TITLE
Wildcards in fortls

### DIFF
--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -256,7 +256,7 @@ class LangServer:
         if len(self.source_dirs) == 1:
             self.source_dirs = []
             for dirName, subdirList, fileList in os.walk(self.root_path):
-                if self.excl_paths.count(dirName) > 0:
+                if dirName in self.excl_paths:
                     while(len(subdirList) > 0):
                         del subdirList[0]
                     continue
@@ -673,7 +673,7 @@ class LangServer:
                     name_replace = candidate.name
                 for member in candidate.mems:
                     tmp_text, _ = member.get_snippet(name_replace)
-                    if tmp_list.count(tmp_text) > 0:
+                    if tmp_text in tmp_list:
                         continue
                     tmp_list.append(tmp_text)
                     item_list.append(build_comp(
@@ -1291,7 +1291,7 @@ class LangServer:
                 _, ext = os.path.splitext(os.path.basename(filename))
                 if FORTRAN_EXT_REGEX.match(ext):
                     filepath = os.path.normpath(os.path.join(source_dir, filename))
-                    if self.excl_paths.count(filepath) > 0:
+                    if filepath in self.excl_paths:
                         continue
                     inc_file = True
                     for excl_suffix in self.excl_suffixes:

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -193,10 +193,12 @@ class LangServer:
         if config_exists:
             try:
                 import json
+                import glob
                 with open(config_path, 'r') as fhandle:
                     config_dict = json.load(fhandle)
                     for excl_path in config_dict.get("excl_paths", []):
-                        self.excl_paths.append(os.path.join(self.root_path, excl_path))
+                        for glob_excl_path in glob.glob(os.path.join(self.root_path, excl_path)):
+                            self.excl_paths.append( glob_excl_path ) 
                     source_dirs = config_dict.get("source_dirs", [])
                     ext_source_dirs = config_dict.get("ext_source_dirs", [])
                     # Legacy definition


### PR DESCRIPTION
First of all, I am so grateful for this project making my life in Fortran and VSCode so much better.

I was missing the feature of wildcards in `.fortls` file, mainly `excl_paths` eg

```
{
  "excl_paths": ["sub*"]
}
```
The change to allow this is line 200. I allowed myself also to change the 

                `if self.excl_paths.count(dirName) > 0:`
to
              `  if dirName in self.excl_paths:`

which I think reads better, but maybe the other implementation has a performance reason or something else I am not aware of.

I was not able to run all test successfully with my Python3.9 on Windows 10. I am getting these assertion errors which I do not how to cope with.

```
Lib\site-packages\pyflakes\test\test_api.py:816: AssertionError
================================================================ short test summary info ================================================================ 
FAILED Lib/site-packages/pyflakes/test/test_api.py::IntegrationTests::test_errors_io - AssertionError: Tuples differ: ('', "E:\\nosave\\Python\\Python3...
FAILED Lib/site-packages/pyflakes/test/test_api.py::IntegrationTests::test_errors_syntax - AssertionError: Tuples differ: ('', "E:\\nosave\\Python\\Pyt...
FAILED Lib/site-packages/pyflakes/test/test_api.py::IntegrationTests::test_fileWithFlakes - AssertionError: Tuples differ: ('', "E:\\nosave\\Python\\Py...
FAILED Lib/site-packages/pyflakes/test/test_api.py::IntegrationTests::test_goodFile - AssertionError: Tuples differ: ('', "E:\\nosave\\Python\\Python39...
FAILED Lib/site-packages/pyflakes/test/test_api.py::IntegrationTests::test_readFromStdin - AssertionError: Tuples differ: ('', "E:\\nosave\\Python\\Pyt...
======================================================= 5 failed, 718 passed, 38 skipped in 8.90s =======================================================

```