### PR TITLE
add LICENSE to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Thanks for this package!

This ensures the LICENSE file is packaged along with the source. While not _strictly_ required for compliance with the MIT license, a number of downstream package management systems strongly encourage self-documenting packages.

Motivation: packaging this for [conda-forge](https://github.com/conda-forge/staged-recipes/pull/17033). At present, I'm also using the source from github to run the unit tests, and having to patch such that it can test the as-installed package, but that's much more subjective.