### PR TITLE
jsonrpc: add support for UNC path

### DIFF
--- a/fortls/jsonrpc.py
+++ b/fortls/jsonrpc.py
@@ -21,7 +21,11 @@ def path_from_uri(uri):
     if not uri.startswith("file://"):
         return uri
     if os.name == "nt":
-        _, path = uri.split("file:///", 1)
+        if uri.startswith("file:///"):
+            _, path = uri.split("file:///", 1)
+        else: # we should have an UNC path
+            _, path = uri.split("file:", 1)
+            return path
     else:
         _, path = uri.split("file://", 1)
     return os.path.normpath(unquote(path))


### PR DESCRIPTION
In the case of a UNC path on windows, the name of the file
in the JSON RPC call is file://SERVER/the/path/file.f90
and it can be accessed in Python with //SERVER/the/path/file.f90

I can not easily test this but I've used the same code on [suricata-language-server](https://github.com/StamusNetworks/suricata-language-server) that is based on this code.

PS: a huge thanks for this code base.